### PR TITLE
simplification + compliance proposal

### DIFF
--- a/python-2.7/Dockerfile
+++ b/python-2.7/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:2.7
+
+ENV SSH_SERVER_KEYS /etc/ssh/host_keys/
+
+ADD entrypoint.sh /root/
+
+EXPOSE 22
+
+RUN apt-get -y update && \
+    apt-get -y install openssh-server && \
+    mkdir -p ${SSH_SERVER_KEYS} && \
+    echo "HostKey ${SSH_SERVER_KEYS}ssh_host_rsa_key" >> /etc/ssh/sshd_config && \
+    echo "HostKey ${SSH_SERVER_KEYS}ssh_host_dsa_key" >> /etc/ssh/sshd_config && \
+    echo "HostKey ${SSH_SERVER_KEYS}ssh_host_ecdsa_key" >> /etc/ssh/sshd_config && \
+    echo "HostKey ${SSH_SERVER_KEYS}ssh_host_ed25519_key" >> /etc/ssh/sshd_config && \
+    sed -i "s/#PermitRootLogin.*/PermitRootLogin\ yes/" /etc/ssh/sshd_config && \
+    echo "root:root" | chpasswd
+
+VOLUME ["${SSH_SERVER_KEYS}"]
+
+ENTRYPOINT ["/root/entrypoint.sh"]
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/python-2.7/Dockerfile
+++ b/python-2.7/Dockerfile
@@ -6,15 +6,13 @@ ADD entrypoint.sh /bin/
 
 EXPOSE 22
 
-RUN apt-get -y update && \
-    apt-get -y install openssh-server && \
+RUN apt-get -y update && apt-get -y install openssh-server && \
     mkdir -p ${SSH_SERVER_KEYS} && \
     echo "HostKey ${SSH_SERVER_KEYS}ssh_host_rsa_key" >> /etc/ssh/sshd_config && \
     echo "HostKey ${SSH_SERVER_KEYS}ssh_host_dsa_key" >> /etc/ssh/sshd_config && \
     echo "HostKey ${SSH_SERVER_KEYS}ssh_host_ecdsa_key" >> /etc/ssh/sshd_config && \
     echo "HostKey ${SSH_SERVER_KEYS}ssh_host_ed25519_key" >> /etc/ssh/sshd_config && \
-    sed -i "s/#PermitRootLogin.*/PermitRootLogin\ yes/" /etc/ssh/sshd_config && \
-    echo "root:root" | chpasswd
+    sed -i "s/#PermitRootLogin.*/PermitRootLogin\ yes/" /etc/ssh/sshd_config
 
 VOLUME ["${SSH_SERVER_KEYS}"]
 

--- a/python-2.7/Dockerfile
+++ b/python-2.7/Dockerfile
@@ -2,7 +2,7 @@ FROM python:2.7
 
 ENV SSH_SERVER_KEYS /etc/ssh/host_keys/
 
-ADD entrypoint.sh /root/
+ADD entrypoint.sh /bin/
 
 EXPOSE 22
 
@@ -18,6 +18,6 @@ RUN apt-get -y update && \
 
 VOLUME ["${SSH_SERVER_KEYS}"]
 
-ENTRYPOINT ["/root/entrypoint.sh"]
+ENTRYPOINT ["/bin/entrypoint.sh"]
 
 CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/python-2.7/entrypoint.sh
+++ b/python-2.7/entrypoint.sh
@@ -11,8 +11,20 @@ if ! ls /etc/ssh/host_keys/ssh_host_* 1> /dev/null 2>&1; then
     chmod 700 /etc/ssh/host_keys/
 fi
 
+stop() {
+    echo -e "\nReceived SIGINT or SIGTERM. Shutting down ${DAEMON}"
+    # Get PID
+    pid=$(cat /var/run/${DAEMON}/${DAEMON}.pid)
+    # Set TERM
+    kill -SIGTERM "${pid}"
+    # Wait for exit
+    wait "${pid}"
+    # All done.
+    echo "Done."
+}
+
 if [ "$(basename $1)" == "${DAEMON}" ]; then
-    echo "Running $@"
+    echo "Running $@, break (^C) or kill ($ sudo docker-compose exec <svc> kill 1) to exit"
     trap stop SIGINT SIGTERM
     $@ &
     pid="$!"

--- a/python-2.7/entrypoint.sh
+++ b/python-2.7/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+DAEMON=sshd
+
+# Generate Host keys, if required
+if ! ls /etc/ssh/host_keys/ssh_host_* 1> /dev/null 2>&1; then
+    ssh-keygen -A
+    mv /etc/ssh/ssh_host_* /etc/ssh/host_keys/
+
+    chmod 600 -R /etc/ssh/host_keys/*
+    chmod 700 /etc/ssh/host_keys/
+fi
+
+if [ "$(basename $1)" == "${DAEMON}" ]; then
+    echo "Running $@"
+    trap stop SIGINT SIGTERM
+    $@ &
+    pid="$!"
+    mkdir -p /var/run/${DAEMON} && echo "${pid}" > /var/run/${DAEMON}/${DAEMON}.pid
+    wait "${pid}" && exit $?
+else  # NOTE not running ${DAEMON}
+    exec "$@"
+fi


### PR DESCRIPTION
Hi, thank you for your work.
I have just successfully set a dev env with PyCharm up and I'm writing a blog post about it (will attach here if you're interested).
I based my docker image on your source and I don't mind leaving it at all on your side and killing `mldwrp/python-sshd` on Docker Hub (plus changing the blog post reference) once we agree on two changes:
1) I've based my image on `python:2.7` and I think the tagging should follow the python's convention, if you need Alpine, just tag it `eugene-s/python-sshd:2.7-alpine` and it will be fine.
2) I've simplified the image to the real bare minimum — I've even removed the password definition since I'm successfully using a key pair through a host volume (will be described in the blog post) — and I'd like it to stay this way.

Well this is all no big deal, but I thought I'd write to you since your work was of help with my setup.
Cheers. 